### PR TITLE
refactor: mentoring room API, feat: schedule of mentoring room API develop

### DIFF
--- a/src/main/java/com/developers/live/developers/mentoring/controller/RoomController.java
+++ b/src/main/java/com/developers/live/developers/mentoring/controller/RoomController.java
@@ -10,9 +10,6 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.List;
 
 @Log4j2
 @RequiredArgsConstructor
@@ -20,15 +17,14 @@ import java.util.List;
 @RestController
 public class RoomController {
     private final RoomService roomService;
-    private final RestTemplate restTemplate;
 
     /**
      * RoomController에 포함된 비즈니스 로직은 RoomService 구현체에서 수행하도록 수정해야 한다.
      */
 
     @GetMapping("")
-    public ResponseEntity<List<RoomListResponseDto>> roomList() {
-        List<RoomListResponseDto> response = roomService.getList();
+    public ResponseEntity<RoomListResponseDto> roomList() {
+        RoomListResponseDto response = roomService.getList();
         log.info("방 전체 목록 조회: " + response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
@@ -41,9 +37,16 @@ public class RoomController {
     }
 
     @GetMapping("/{param}")
-    public ResponseEntity<List<RoomListResponseDto>> roomListWithParam(@PathVariable("param") String param) {
-        List<RoomListResponseDto> response = roomService.getListWithSearch(param);
+    public ResponseEntity<RoomListResponseDto> roomListWithParam(@PathVariable("param") String param) {
+        RoomListResponseDto response = roomService.getListWithSearch(param);
         log.info("검색어로 방 목록 조회: " + response);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/sort/recent")
+    public ResponseEntity<RoomListResponseDto> roomListWithRecent() {
+        RoomListResponseDto response = roomService.getListWithRecent();
+        log.info("최신순으로 정렬 후 목록 조회: " + response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/developers/live/developers/mentoring/controller/ScheduleController.java
+++ b/src/main/java/com/developers/live/developers/mentoring/controller/ScheduleController.java
@@ -1,0 +1,52 @@
+package com.developers.live.developers.mentoring.controller;
+
+import com.developers.live.developers.mentoring.dto.ScheduleAddRequestDto;
+import com.developers.live.developers.mentoring.dto.ScheduleAddResponseDto;
+import com.developers.live.developers.mentoring.dto.ScheduleDeleteResponseDto;
+import com.developers.live.developers.mentoring.dto.ScheduleListResponseDto;
+import com.developers.live.developers.mentoring.service.ScheduleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/schedules")
+@RestController
+public class ScheduleController {
+
+  private final ScheduleService scheduleService;
+
+  @PostMapping("")
+  public ResponseEntity<ScheduleAddResponseDto> scheduleAdd(@RequestBody @Valid ScheduleAddRequestDto request) {
+    ScheduleAddResponseDto response = scheduleService.addSchedule(request);
+    log.info("멘토링룸에 대한 일정 추가: " + response);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @DeleteMapping("/{scheduleId}")
+  public ResponseEntity<ScheduleDeleteResponseDto> scheduleDelete(@PathVariable Long scheduleId) {
+    ScheduleDeleteResponseDto response = scheduleService.deleteSchedule(scheduleId);
+    log.info("일정 삭제: " + response);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @GetMapping("/{memberId}/mentor")
+  public ResponseEntity<ScheduleListResponseDto> scheduleAsMentor(@PathVariable Long memberId) {
+    ScheduleListResponseDto response = scheduleService.getScheduleListAsMentor(memberId);
+    log.info("사용자의 멘토로서의 모든 일정 조회: " + response);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @GetMapping("/{memberId}/mentee")
+  public ResponseEntity<ScheduleListResponseDto> scheduleAsMentee(@PathVariable Long memberId) {
+    ScheduleListResponseDto response = scheduleService.getScheduleListAsMentee(memberId);
+    log.info("사용자의 멘티로서의 모든 일정 조회: " + response);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/RoomAddRequestDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/RoomAddRequestDto.java
@@ -22,9 +22,8 @@ public class RoomAddRequestDto {
     @Size(max = 500)
     private String description;
 
-    // TODO: point validation 최소, 최댓값 결정 필요
     @NotNull
-    @Min(0)
-    @Max(100)
+    @Min(30)
+    @Max(50)
     private Long point;
 }

--- a/src/main/java/com/developers/live/developers/mentoring/dto/RoomGetDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/RoomGetDto.java
@@ -5,14 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Data
-public class RoomListResponseDto {
-  private String code;
-  private String msg;
-  private List<RoomGetDto> data;
+public class RoomGetDto {
+  private Long mentoringRoomId;
+  private String mentorName;
+  private String title;
+  private String description;
+  private Long point;
 }

--- a/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleAddRequestDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleAddRequestDto.java
@@ -1,0 +1,27 @@
+package com.developers.live.developers.mentoring.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ScheduleAddRequestDto {
+  @NotNull
+  private Long mentoringRoomId;
+
+  @NotNull
+  private Long mentorId;
+
+  @NotNull
+  private LocalDateTime start;
+
+  @NotNull
+  private LocalDateTime end;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleAddResponseDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleAddResponseDto.java
@@ -1,0 +1,16 @@
+package com.developers.live.developers.mentoring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ScheduleAddResponseDto {
+  private String code;
+  private String msg;
+  private String data;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleDeleteResponseDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleDeleteResponseDto.java
@@ -1,0 +1,16 @@
+package com.developers.live.developers.mentoring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ScheduleDeleteResponseDto {
+  private String code;
+  private String msg;
+  private String data;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleGetDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleGetDto.java
@@ -1,0 +1,21 @@
+package com.developers.live.developers.mentoring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ScheduleGetDto {
+  private Long scheduleId;
+  private String mentoringRoomTitle;
+  private String mentorName;
+  private String menteeName;
+  private LocalDateTime start;
+  private LocalDateTime end;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleListResponseDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/ScheduleListResponseDto.java
@@ -1,0 +1,18 @@
+package com.developers.live.developers.mentoring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class ScheduleListResponseDto {
+  private String code;
+  private String msg;
+  private List<ScheduleGetDto> data;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
+++ b/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
@@ -1,0 +1,50 @@
+package com.developers.live.developers.mentoring.entity;
+
+import com.developers.live.developers.common.entity.BaseTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GenerationType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@ToString
+@Getter
+@Where(clause = "deleted_at is NULL")
+@SQLDelete(sql = "update mentoring_room_schedule set deleted_at = CURRENT_TIMESTAMP where schedule_id = ?")
+@Table(name = "mentoring_room_schedule")
+@Entity
+public class Schedule extends BaseTime {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "scheduleId", nullable = false)
+  private Long scheduleId;
+  @Column(name = "mentoringRoomId", nullable = false)
+  private Long mentoringRoomId;
+  @Column(name = "mentorId", nullable = false)
+  private Long mentorId;
+  @Column(name = "menteeId")
+  private Long menteeId;
+  @Column(name = "start", nullable = false)
+  private LocalDateTime start;
+  @Column(name = "end", nullable = false)
+  private LocalDateTime end;
+
+  @Builder
+  public Schedule(Long mentoringRoomId, Long mentorId, Long menteeId, LocalDateTime start, LocalDateTime end) {
+    this.mentoringRoomId = mentoringRoomId;
+    this.mentorId = mentorId;
+    this.menteeId = menteeId;
+    this.start = start;
+    this.end = end;
+  }
+}

--- a/src/main/java/com/developers/live/developers/mentoring/repository/RoomRepository.java
+++ b/src/main/java/com/developers/live/developers/mentoring/repository/RoomRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
   List<Room> findByTitleContaining(String param);
+  List<Room> findAllByOrderByUpdatedAtDesc();
 }

--- a/src/main/java/com/developers/live/developers/mentoring/repository/ScheduleRespository.java
+++ b/src/main/java/com/developers/live/developers/mentoring/repository/ScheduleRespository.java
@@ -1,0 +1,14 @@
+package com.developers.live.developers.mentoring.repository;
+
+import com.developers.live.developers.mentoring.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ScheduleRespository extends JpaRepository<Schedule, Long> {
+
+  List<Schedule> findAllByMentorId(Long memberId);
+  List<Schedule> findAllByMenteeId(Long memberId);
+}

--- a/src/main/java/com/developers/live/developers/mentoring/service/RoomService.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/RoomService.java
@@ -2,6 +2,7 @@ package com.developers.live.developers.mentoring.service;
 
 import com.developers.live.developers.mentoring.dto.RoomAddRequestDto;
 import com.developers.live.developers.mentoring.dto.RoomAddResponseDto;
+import com.developers.live.developers.mentoring.dto.RoomGetDto;
 import com.developers.live.developers.mentoring.dto.RoomListResponseDto;
 import com.developers.live.developers.mentoring.entity.Room;
 
@@ -9,14 +10,13 @@ import java.util.List;
 
 public interface RoomService {
 
-  List<RoomListResponseDto> getList();
-
+  RoomListResponseDto getList();
   RoomAddResponseDto addRoom(RoomAddRequestDto req);
+  RoomListResponseDto getListWithSearch(String param);
+  RoomListResponseDto getListWithRecent();
 
-  List<RoomListResponseDto> getListWithSearch(String param);
-
-  default RoomListResponseDto entityToDto(Room entity) {
-    return RoomListResponseDto.builder()
+  default RoomGetDto entityToDto(Room entity) {
+    return RoomGetDto.builder()
             .mentoringRoomId(entity.getMentoringRoomId())
 
             // TODO: entity의 mentorId 데이터로 mentor 이름 가져오기

--- a/src/main/java/com/developers/live/developers/mentoring/service/RoomServiceImpl.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/RoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.developers.live.developers.mentoring.service;
 
 import com.developers.live.developers.mentoring.dto.RoomAddRequestDto;
 import com.developers.live.developers.mentoring.dto.RoomAddResponseDto;
+import com.developers.live.developers.mentoring.dto.RoomGetDto;
 import com.developers.live.developers.mentoring.dto.RoomListResponseDto;
 import com.developers.live.developers.mentoring.entity.Room;
 import com.developers.live.developers.mentoring.repository.RoomRepository;
@@ -19,9 +20,13 @@ public class RoomServiceImpl implements RoomService {
   private final RoomRepository roomRepository;
 
   @Override
-  public List<RoomListResponseDto> getList() {
-    List<Room> entityList = roomRepository.findAll();
-    return entityList.stream().map(room -> entityToDto(room)).collect(Collectors.toList());
+  public RoomListResponseDto getList() {
+    List<RoomGetDto> dtoList = roomRepository.findAll().stream().map(room -> entityToDto(room)).toList();
+    return RoomListResponseDto.builder()
+            .code(String.valueOf(HttpStatus.OK))
+            .msg("정상적으로 멘토링방 전체 조회가 되었습니다.")
+            .data(dtoList)
+            .build();
   }
 
   @Override
@@ -43,8 +48,22 @@ public class RoomServiceImpl implements RoomService {
   }
 
   @Override
-  public List<RoomListResponseDto> getListWithSearch(String param) {
-    List<Room> entityList = roomRepository.findByTitleContaining(param);
-    return entityList.stream().map(room -> entityToDto(room)).collect(Collectors.toList());
+  public RoomListResponseDto getListWithSearch(String param) {
+    List<RoomGetDto> dtoList = roomRepository.findByTitleContaining(param.replaceAll("\\s+", " ")).stream().map(room -> entityToDto(room)).toList();
+    return RoomListResponseDto.builder()
+            .code(String.valueOf(HttpStatus.OK))
+            .msg("정상적으로 멘토링방 문자열 검색이 되었습니다.")
+            .data(dtoList)
+            .build();
+  }
+
+  @Override
+  public RoomListResponseDto getListWithRecent() {
+    List<RoomGetDto> dtoList = roomRepository.findAllByOrderByUpdatedAtDesc().stream().map(room -> entityToDto(room)).toList();
+    return RoomListResponseDto.builder()
+            .code(String.valueOf(HttpStatus.OK))
+            .msg("정상적으로 최신순으로 정렬된 채팅방 목록이 조회되었습니다.")
+            .data(dtoList)
+            .build();
   }
 }

--- a/src/main/java/com/developers/live/developers/mentoring/service/ScheduleService.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/ScheduleService.java
@@ -1,0 +1,25 @@
+package com.developers.live.developers.mentoring.service;
+
+import com.developers.live.developers.mentoring.dto.*;
+import com.developers.live.developers.mentoring.entity.Schedule;
+
+public interface ScheduleService {
+
+  ScheduleAddResponseDto addSchedule(ScheduleAddRequestDto request);
+  ScheduleDeleteResponseDto deleteSchedule(Long scheduleId);
+  ScheduleListResponseDto getScheduleListAsMentor(Long memberId);
+  ScheduleListResponseDto getScheduleListAsMentee(Long memberId);
+  String getMentoringRoomTitle(Long mentoringRoomId);
+
+  default ScheduleGetDto entityToDto(Schedule entity) {
+    return ScheduleGetDto.builder()
+            .scheduleId(entity.getScheduleId())
+            .mentoringRoomTitle(getMentoringRoomTitle(entity.getMentoringRoomId()))
+            // TODO: entity의 mentorId, menteeId 데이터로 mentorName, menteeName 가져오기
+            .mentorName("")
+            .menteeName("")
+            .start(entity.getStart())
+            .end(entity.getEnd())
+            .build();
+  }
+}

--- a/src/main/java/com/developers/live/developers/mentoring/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/ScheduleServiceImpl.java
@@ -1,0 +1,95 @@
+package com.developers.live.developers.mentoring.service;
+
+import com.developers.live.developers.mentoring.dto.*;
+import com.developers.live.developers.mentoring.entity.Room;
+import com.developers.live.developers.mentoring.entity.Schedule;
+import com.developers.live.developers.mentoring.repository.RoomRepository;
+import com.developers.live.developers.mentoring.repository.ScheduleRespository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class ScheduleServiceImpl implements ScheduleService {
+
+  private final RoomRepository roomRepository;
+  private final ScheduleRespository scheduleRespository;
+
+  @Override
+  public ScheduleAddResponseDto addSchedule(ScheduleAddRequestDto request) {
+    Optional<Room> room = roomRepository.findById(request.getMentoringRoomId());
+
+    ScheduleAddResponseDto response;
+    if (room.isPresent()) {
+      Schedule schedule = scheduleRespository.save(
+              Schedule.builder()
+                      .mentoringRoomId(request.getMentoringRoomId())
+                      .mentorId(request.getMentorId())
+                      .start(request.getStart())
+                      .end(request.getEnd())
+                      .build());
+
+      response = ScheduleAddResponseDto.builder()
+              .code(String.valueOf(HttpStatus.OK))
+              .msg("일정이 추가되었습니다.")
+              .data(String.valueOf(schedule.getScheduleId()))
+              .build();
+    }
+    else {
+      response = ScheduleAddResponseDto.builder()
+              .code(String.valueOf(HttpStatus.NOT_FOUND))
+              .msg("방에 대한 정보를 찾지 못했습니다.")
+              .data("null")
+              .build();
+    }
+    return response;
+  }
+
+  @Override
+  public ScheduleDeleteResponseDto deleteSchedule(Long scheduleId) {
+    scheduleRespository.deleteById(scheduleId);
+    return ScheduleDeleteResponseDto.builder()
+            .code(String.valueOf(HttpStatus.OK))
+            .msg("일정이 삭제되었습니다.")
+            .data(String.valueOf(scheduleId))
+            .build();
+  }
+
+  @Override
+  public ScheduleListResponseDto getScheduleListAsMentor(Long memberId) {
+    List<ScheduleGetDto> dtoList = scheduleRespository.findAllByMentorId(memberId).stream().map(schedule -> entityToDto(schedule)).toList();
+
+    return ScheduleListResponseDto.builder()
+            .code(String.valueOf(HttpStatus.OK))
+            .msg("멘토로서의 일정 조회가 완료되었습니다.")
+            .data(dtoList)
+            .build();
+  }
+
+  @Override
+  public ScheduleListResponseDto getScheduleListAsMentee(Long memberId) {
+    List<ScheduleGetDto> dtoList = scheduleRespository.findAllByMenteeId(memberId).stream().map(schedule -> entityToDto(schedule)).toList();
+
+    return ScheduleListResponseDto.builder()
+            .code(String.valueOf(HttpStatus.OK))
+            .msg("멘티로서의 일정 조회가 완료되었습니다.")
+            .data(dtoList)
+            .build();
+  }
+
+  @Override
+  public String getMentoringRoomTitle(Long mentoringRoomId) {
+    Optional<Room> foundRoom = roomRepository.findById(mentoringRoomId);
+
+    if (foundRoom.isPresent()) {
+      return foundRoom.get().getTitle();
+    }
+    else {
+      return null;
+    }
+  }
+}

--- a/src/test/java/com/developers/live/developers/repository/RoomRepositoryTest.java
+++ b/src/test/java/com/developers/live/developers/repository/RoomRepositoryTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -39,7 +38,15 @@ public class RoomRepositoryTest {
     @Test
     public void get() {
         // given
-        Long roomId = 1L;
+        Room room = Room.builder()
+                .mentorId(1L)
+                .title("mentoring room")
+                .description("contents is ...")
+                .point(10L)
+                .build();
+        Room createdRoom = roomRepository.save(room);
+
+        Long roomId = room.getMentoringRoomId();
 
         // when
         Optional<Room> foundRoom = roomRepository.findById(roomId);
@@ -48,5 +55,4 @@ public class RoomRepositoryTest {
         assertThat(foundRoom.isPresent()).isEqualTo(true);
         assertThat(foundRoom.get().getMentoringRoomId()).isEqualTo(roomId);
     }
-
 }

--- a/src/test/java/com/developers/live/developers/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/developers/live/developers/repository/ScheduleRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.developers.live.developers.repository;
+
+import com.developers.live.developers.mentoring.entity.Room;
+import com.developers.live.developers.mentoring.entity.Schedule;
+import com.developers.live.developers.mentoring.repository.ScheduleRespository;
+import com.developers.live.developers.mentoring.service.ScheduleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class ScheduleRepositoryTest {
+
+  @Autowired ScheduleRespository scheduleRespository;
+
+  @Test
+  void save() {
+    // given
+    Schedule room = Schedule.builder()
+            .mentoringRoomId(1L)
+            .mentorId(1L)
+            .menteeId(2L)
+            .start(LocalDateTime.now())
+            .end(LocalDateTime.now().minusHours(1L))
+            .build();
+
+    scheduleRespository.save(room);
+
+    // when
+    List<Schedule> scheduleList = scheduleRespository.findAll();
+
+    // then
+    Optional<Schedule> result = scheduleRespository.findById(room.getScheduleId());
+    assertThat(result.isPresent()).isEqualTo(true);
+    assertThat(result.get().getMentorId()).isEqualTo(1L);
+  }
+
+  @Test
+  public void get() {
+    // given
+    Schedule schedule = Schedule.builder()
+            .mentorId(1L)
+            .menteeId(2L)
+            .start(LocalDateTime.now())
+            .start(LocalDateTime.now().plusHours(1))
+            .build();
+    Schedule createdSchedule = scheduleRespository.save(schedule);
+
+    Long scheduleId = schedule.getScheduleId();
+
+    // when
+    Optional<Schedule> foundSchedule = scheduleRespository.findById(scheduleId);
+
+    // then
+    assertThat(foundSchedule.isPresent()).isEqualTo(true);
+    assertThat(foundSchedule.get().getScheduleId()).isEqualTo(scheduleId);
+  }
+}

--- a/src/test/java/com/developers/live/developers/service/RoomServiceTest.java
+++ b/src/test/java/com/developers/live/developers/service/RoomServiceTest.java
@@ -23,11 +23,11 @@ public class RoomServiceTest {
     // given
 
     // when
-    List<RoomListResponseDto> allRoom = roomService.getList();
+    RoomListResponseDto response = roomService.getList();
 
     // then
-    System.out.println("현재 만들어진 멘토링룸 갯수: " + allRoom.size());
-    System.out.println("전체 멘토링룸 조회: " + allRoom);
+    System.out.println("현재 만들어진 멘토링룸 갯수: " + response.getData().size());
+    System.out.println("전체 멘토링룸 조회: " + response);
   }
 
   @Test
@@ -53,10 +53,21 @@ public class RoomServiceTest {
     String param = "mentoring";
 
     // when
-    List<RoomListResponseDto> roomList = roomService.getListWithSearch(param);
+    RoomListResponseDto roomList = roomService.getListWithSearch(param);
 
     // then
-    System.out.println(param + " 으로 찾은 멘토링룸 개수: " + roomList.size());
+    System.out.println(param + " 으로 찾은 멘토링룸 개수: " + roomList.getData().size());
     System.out.println(param + " 으로 찾은 멘토링룸 조회: " + roomList);
+  }
+
+  @Test
+  void 최신순으로_멘토링룸_정렬() {
+    // given
+
+    // when
+    RoomListResponseDto roomList = roomService.getListWithRecent();
+
+    // then
+    System.out.println("최신순으로 정렬한 멘토링룸 목록: " + roomList.getData());
   }
 }

--- a/src/test/java/com/developers/live/developers/service/ScheduleServiceTest.java
+++ b/src/test/java/com/developers/live/developers/service/ScheduleServiceTest.java
@@ -1,0 +1,49 @@
+package com.developers.live.developers.service;
+
+import com.developers.live.developers.mentoring.dto.*;
+import com.developers.live.developers.mentoring.service.ScheduleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class ScheduleServiceTest {
+
+  @Autowired ScheduleService scheduleService;
+
+  @Test
+  public void 스케쥴_추가() {
+    // given
+    ScheduleAddRequestDto req = ScheduleAddRequestDto.builder()
+            .mentorId(1L)
+            .mentoringRoomId(2L)
+            .start(LocalDateTime.now())
+            .end(LocalDateTime.now().plusHours(1))
+            .build();
+
+    // when
+    ScheduleAddResponseDto response = scheduleService.addSchedule(req);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(String.valueOf(HttpStatus.OK));
+  }
+
+  @Test
+  public void 멘토_스케쥴_조회() {
+    // given
+    Long memberId = 1L;
+
+    // when
+    ScheduleListResponseDto response = scheduleService.getScheduleListAsMentor(memberId);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(String.valueOf(HttpStatus.OK));
+  }
+
+  // 멘티 스케쥴 조회
+}


### PR DESCRIPTION
# refactor: mentoring room API
## 🤔 Motivation
- 멘토링룸 조회 요청에 대한 response 데이터 포맷 수정
- 멘토링룸 목록 최신순으로 정렬 후 반환

<br>

## 💡 Key Changes
- 멘토링룸 조회 시, 반환하는 데이터에 멘토링룸 정보를 넣어넣고 List<responseDto> 형식으로 반환했던 것을 responseDto 안에 List<GetDto>를 data라는 이름으로 넣은 후, code와 msg를 함께 반환하도록 수정했습니다.
- 멘토링룸 목록을 최신순으로 정렬 후 반환하도록 구현했습니다.

<br>

close #12 
close #13 

# feat: schedule of mentoring room API develop
## 🤔 Motivation
- 멘토의 멘토링룸에 대한 일정 추가 기능 개발
- 멘토로서의, 멘티로서의 일정 조회 기능 개발
- 사용자의 일정 삭제 기능 개발

<br>

## 💡 Key Changes
- 멘토링룸과 스케쥴은 1:N 관계(단방향)로 구성했습니다.
- 멘토가 멘토링룸에 대한 일정을 추가할 때 먼저 mentoringRoomId로 멘토링룸의 유무를 확인하고 유효하다면 스케쥴이 정상적으로 등록되도록 구현했습니다.
- 모든 사용자의 일정 삭제는 동일하게 scheduleId를 받아 삭제되도록 했습니다.
- 모든 일정 조회할 때 클라이언트 단에서 구분해서 보여줄 수 있도록 멘토로서의 일정, 멘티로서의 일정 조회를 따로 구성했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @Jooney-95 
- @paduck-96 
 
close #8  
close #9 
close #10  